### PR TITLE
Ошибка запроса при переходе в DevTool. Ошибка появляется в консоли.

### DIFF
--- a/public/metamodel/dochub/entities/aspects/base.yaml
+++ b/public/metamodel/dochub/entities/aspects/base.yaml
@@ -56,7 +56,7 @@ entities:
             };
             $domains := $split($id, ".");
             $config.root_menu & "/" & $join($map($domains, function($domain, $index) {(
-                $lookup($aspects, $join($arrleft($domains, $index), ".")).title
+                $lookup($aspects, $join($arrleft($domains, $index), ".")).location
             )}), "/");
         )};
         [$append([{

--- a/src/frontend/components/JSONata/DevTool.vue
+++ b/src/frontend/components/JSONata/DevTool.vue
@@ -221,10 +221,10 @@
         this.doAutoExecute();
       },
       refreshOrigins() {
-        const pipe = query.expression(`[(datasets.$spread().{
+        const pipe = query.expression(`([datasets.$spread().{
           "id": $keys()[0],
           "title": *.title
-        })]`, null, null, true, { log: this.log});
+        }])`, null, null, true, { log: this.log});
         pipe.evaluate().then((data) => this.origins = data);
       },
       doAutoExecute() {


### PR DESCRIPTION
<img width="1296" height="180" alt="image" src="https://github.com/user-attachments/assets/0a1b9e02-66e3-4141-b588-1b4966e6efa3" />

При разборе запроса выясняется, что в строке вот такой запрос:
```yaml
[(datasets.$spread().{
          "id": $keys()[0],
          "title": *.title
        })]
```
Он генерирует ошибку:
<img width="1196" height="217" alt="image" src="https://github.com/user-attachments/assets/e84a0735-9dc8-4447-95ad-360cf9a62a15" />


